### PR TITLE
Updated multiple author check to be based on email rather than name

### DIFF
--- a/src/policies.rs
+++ b/src/policies.rs
@@ -118,10 +118,7 @@ fn verify_commit_signatures<G: Git>(git: &G, commits: &Vec<Commit<'_>>, fingerpr
 fn verify_different_authors<G: Git>(commits: &Vec<Commit<'_>>) -> Result<(), Box<dyn Error>> {
     info!("Verify multiple authors");
     let authors : HashSet<_> = commits.iter().filter_map(|c| {
-        match c.author().name() {
-            Some(n) => Some(n.to_string()),
-            _ => None
-        }
+        c.author().email().map(|e| e.to_string())
     }).collect();
     debug!("Author set: {:#?}", authors);
     if authors.len() <= 1 {


### PR DESCRIPTION
Devs might have their name entered slightly differently in different places. The email
address is perhaps a better id value for building the hashset. This also matches what
we're doing with the fingerprints and committer field.