### PR TITLE
Merge reproduction perf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capn"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "capn"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Justin Wernick <justin@jemstep.com>"]
 edition = "2018"
 

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -70,37 +70,35 @@ pub fn verify_git_commits<G: Git, P: Gpg>(
         )?;
 
         if config.verify_email_addresses {
-            policy_result = policy_result.and(verify_email_addresses(
-                &config.author_domain,
-                &config.committer_domain,
-                &not_manually_verified_commits,
-            ));
+            policy_result = policy_result.and_then(|| {
+                Ok(verify_email_addresses(
+                    &config.author_domain,
+                    &config.committer_domain,
+                    &not_manually_verified_commits,
+                ))
+            })?;
         }
 
         if config.verify_commit_signatures {
-            policy_result = policy_result.and(verify_commit_signatures::<G, P>(
-                git,
-                &gpg,
-                &not_manually_verified_commits,
-                &mut keyring,
-            )?);
+            policy_result = policy_result.and_then(|| {
+                verify_commit_signatures::<G, P>(
+                    git,
+                    &gpg,
+                    &not_manually_verified_commits,
+                    &mut keyring,
+                )
+            })?;
         }
 
         if config.verify_different_authors {
-            policy_result = policy_result.and(verify_different_authors::<G>(
-                &all_commits,
-                git,
-                &ref_update,
-            )?);
+            policy_result = policy_result
+                .and_then(|| verify_different_authors::<G>(&all_commits, git, &ref_update))?;
         }
 
         if config.verify_rebased {
-            policy_result = policy_result.and(verify_rebased::<G>(
-                &all_commits,
-                git,
-                &ref_update,
-                &config.override_tag_pattern,
-            )?);
+            policy_result = policy_result.and_then(|| {
+                verify_rebased::<G>(&all_commits, git, &ref_update, &config.override_tag_pattern)
+            })?;
         }
     }
 

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -79,14 +79,9 @@ pub fn verify_git_commits<G: Git, P: Gpg>(
             })?;
         }
 
-        if config.verify_commit_signatures {
+        if config.verify_rebased {
             policy_result = policy_result.and_then(|| {
-                verify_commit_signatures::<G, P>(
-                    git,
-                    &gpg,
-                    &not_manually_verified_commits,
-                    &mut keyring,
-                )
+                verify_rebased::<G>(&all_commits, git, &ref_update, &config.override_tag_pattern)
             })?;
         }
 
@@ -95,9 +90,14 @@ pub fn verify_git_commits<G: Git, P: Gpg>(
                 .and_then(|| verify_different_authors::<G>(&all_commits, git, &ref_update))?;
         }
 
-        if config.verify_rebased {
+        if config.verify_commit_signatures {
             policy_result = policy_result.and_then(|| {
-                verify_rebased::<G>(&all_commits, git, &ref_update, &config.override_tag_pattern)
+                verify_commit_signatures::<G, P>(
+                    git,
+                    &gpg,
+                    &not_manually_verified_commits,
+                    &mut keyring,
+                )
             })?;
         }
     }

--- a/src/policies/policy_result.rs
+++ b/src/policies/policy_result.rs
@@ -1,4 +1,5 @@
 use git2::Oid;
+use std::error::Error;
 use std::fmt;
 use std::iter;
 
@@ -20,6 +21,15 @@ impl PolicyResult {
         match self {
             PolicyResult::Ok => res,
             x => x,
+        }
+    }
+    pub fn and_then(
+        self,
+        mut next: impl FnMut() -> Result<PolicyResult, Box<dyn Error>>,
+    ) -> Result<PolicyResult, Box<dyn Error>> {
+        match self {
+            PolicyResult::Ok => next(),
+            x => Ok(x),
         }
     }
     pub fn is_ok(&self) -> bool {


### PR DESCRIPTION
# The problem: #

When someone clicks the 'merge' button in Github, the merge commit that Github creates doesn't have a GPG signature. We've decided that it is fine to exclude these unsigned commits from the signature verification in Captain Git Hook as long as there are NO CODE CHANGES.

If the branch was rebased before clicking the merge button, this check is trivial. Each commit has a hash of its filesystem tree. We compare the tree hashes to the parent commits, and if any match then there were no code changes introduced in that unsigned commit.

If the branch isn't rebased, then there was work done to merge the two branches. We want to assert that there weren't any code changes introduced, so we use libgit to take the parents are reproduce the merge. If our reproduced merge comes up with the same filesystem tree hash, then this was a 'trivial merge', without any new code changes introduced, and it passes the signature check.

Constraint 1: In libgit, I haven't found any way to calculate the filesystem tree hash without actually writing the filesystem tree to disk.

Constraint 2: In GitHub, in the pre-receive hook, you have the repository mounted in a read-only filesystem.

To get around constraint 1 and 2, we reproduce the merge in a separate bare repo that we create in /tmp. So we do the merge of the two branches, then write the resulting filesystem tree in /tmp.

Constraint 3: In the latest version of libgit, they've added a safety check while writing the filesystem tree that the objects the tree refers to have to actually exist. This means that we can't write the tree to an empty repo anymore, we actually have to clone the repo to /tmp and work with the clone.

That last constraint is what's biting us now. Stormsend is a large repository, and when we try to reproduce a merge by cloning it to /tmp, we timeout during the clone.

# This PR #

- Exits early on failures, and reorders checks to do the rebase check before the signature check
- Does a `--shared` clone of the repo for reproducing merges, decreasing the overhead of copying object files.